### PR TITLE
Force matplotlib to use the 'inline' backend by default

### DIFF
--- a/alpaca_kernel/ipkernel.py
+++ b/alpaca_kernel/ipkernel.py
@@ -21,6 +21,7 @@ from contextlib import contextmanager
 from functools import partial
 
 import numpy as np
+import matplotlib as mpl
 from matplotlib import pyplot as plt
 from tornado import websocket
 
@@ -83,6 +84,8 @@ def _get_comm_manager(*args, **kwargs):
 
 comm.create_comm = _create_comm
 comm.get_comm_manager = _get_comm_manager
+
+mpl.use('inline') # Force the matplotlib backend to be 'inline' by default
 
 ap_plot = argparse.ArgumentParser(prog="%plot", add_help=False)
 ap_plot.add_argument('--mode', type=str, default='matplotlib')


### PR DESCRIPTION
Since version 3.9.0 of matplotlib., backend mapping is managed by matplotlib itself instead of IPython (see matplotlib/matplotlib#27948), which creates confusion between the GUI name `"osx"` and the backend name `"macosx"` on macOS, resulting in the exception `IPython.core.error.UsageError : Invalid GUI request 'macosx'`. This could be easily resolved by forcing the ALPACA kernel to use the `inline` backend by default.