### PR TITLE
fixed plotting issue VScode

### DIFF
--- a/alpaca_kernel/alpaca/utils.py
+++ b/alpaca_kernel/alpaca/utils.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 def _to_png(fig):
-    """Return a base64-encoded PNG from a
+    """Return a not base64-encoded PNG from a
     matplotlib figure."""
     imgdata = BytesIO()
     fig.savefig(imgdata, format='png')

--- a/alpaca_kernel/alpaca/utils.py
+++ b/alpaca_kernel/alpaca/utils.py
@@ -9,7 +9,7 @@ def _to_png(fig):
     """Return a not base64-encoded PNG from a
     matplotlib figure."""
     imgdata = BytesIO()
-    fig.savefig(imgdata, format='png')
+    fig.savefig(imgdata, format='png',bbox_inches='tight')
     imgdata.seek(0)
     return imgdata.read()
 

--- a/alpaca_kernel/alpaca/utils.py
+++ b/alpaca_kernel/alpaca/utils.py
@@ -11,8 +11,7 @@ def _to_png(fig):
     imgdata = BytesIO()
     fig.savefig(imgdata, format='png')
     imgdata.seek(0)
-    return urllib.parse.quote(
-        base64.b64encode(imgdata.getvalue()))
+    return imgdata.read()
 
 
 def string_to_numpy(string):


### PR DESCRIPTION
Removing the base64 encoding in _to_png function prevents VScode from double encoding every plot. Now returning just bytes